### PR TITLE
Upgrade got client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ consulRequest(config)
 
 ## Upgrade Path 3.0.0 to 4.0.0
 
-The `3.0.0` version of `consul-client` depended on a module called `got-promise` which returned promised backed by the
+The `3.0.0` version of `consul-client` depended on a module called `got-promise` which returned promises backed by the
 expanded `bluebird` API for promises. The `got-promise` module is now deprecated because `got` supports promises by
 default now. Version `4.0.0` of `consul-client` now depends directly on `got`, but because `got` uses `pinkie-promise`
 as a Promise polyfill instead of `bluebird`, any code which used version `3.0.0` of `consul-client` and took advantage

--- a/README.md
+++ b/README.md
@@ -28,3 +28,35 @@ consulRequest(config)
   .then(console.log) // log successes
   .catch(console.log); // catch and log all errors
 ```
+
+## Upgrade Path 3.0.0 to 4.0.0
+
+The `3.0.0` version of `consul-client` depended on a module called `got-promise` which returned promised backed by the
+expanded `bluebird` API for promises. The `got-promise` module is now deprecated because `got` supports promises by
+default now. Version `4.0.0` of `consul-client` now depends directly on `got`, but because `got` uses `pinkie-promise`
+as a Promise polyfill instead of `bluebird`, any code which used version `3.0.0` of `consul-client` and took advantage
+of any features of `bluebird` promises will now not work. To fix this issue you can either not use any of the cool
+features of `bluebird` or you can explicitly wrap all of your calls to `consul-client` manually with `Bluebird.resolve`.
+
+```javascript
+import Bluebird from 'bluebird';
+import consulClient from 'consul-client';
+
+function consulRequestBluebirdDecorator(consulRequest) {
+  return function(config) {
+    return Bluebird.resolve(consulRequest(config));
+  }
+}
+
+const consulHost = 'my.consul.com'; // e.g 172.x.x.x:8500
+const consulRequest = consulRequestBluebirdDecorator(consulClient(consulHost));
+
+// Discovers an instance of the users service
+// and POSTs body to it's /users/login route.
+consulRequest(config)
+    .map(console.log) // USE BLUEBIRD!!! map and log successes
+    .catch(console.log); // catch and log all errors
+```
+
+For convenience this wrapper is provided for you, just change
+all of your `require('consul-client')` to `require('consul-client/bluebird')`.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ consulRequest(config)
 ## Upgrade Path 3.0.0 to 4.0.0
 
 The `3.0.0` version of `consul-client` depended on a module called `got-promise` which returned promises backed by the
-expanded `bluebird` API for promises. The `got-promise` module is now deprecated because `got` supports promises by
-default now. Version `4.0.0` of `consul-client` now depends directly on `got`, but because `got` uses `pinkie-promise`
+expanded `bluebird` API for promises. The `got-promise` module is deprecated because `got` supports promises by
+default now. Version `4.0.0` of `consul-client` depends directly on `got`, but because `got` uses `pinkie-promise`
 as a Promise polyfill instead of `bluebird`, any code which used version `3.0.0` of `consul-client` and took advantage
-of any features of `bluebird` promises will now not work. To fix this issue you can either not use any of the cool
+of `bluebird` features will break. To fix this issue you can either not use any of the cool
 features of `bluebird` or you can explicitly wrap all of your calls to `consul-client` manually with `Bluebird.resolve`.
 
 ```javascript

--- a/bluebird.js
+++ b/bluebird.js
@@ -1,0 +1,14 @@
+var Bluebird = require('bluebird');
+var consulClient = require('./index');
+
+function consulRequestBluebirdDecorator(consulRequest) {
+  return function(config) {
+    return Bluebird.resolve(consulRequest(config));
+  }
+}
+
+function consulClientBluebird(host) {
+  return consulRequestBluebirdDecorator(consulClient(host));
+}
+
+module.exports = consulClientBluebird;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var gulpIstanbul = require('gulp-istanbul');
 var gulpMocha = require('gulp-mocha');
 
 gulp.task('test', function(cb) {
-  gulp.src(['lib/**/*.js', 'index.js'])
+  gulp.src(['lib/**/*.js', 'index.js', 'bluebird.js'])
     .pipe(gulpIstanbul())
     .pipe(gulpIstanbul.hookRequire())
     .on('finish', function() {

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ var prepareRequestOptions = require('./lib/prepareRequestOptions');
 var serviceUrlComposer = require('./lib/serviceUrlComposer');
 
 /**
- * Returns a service request function, closure scopes the host configuration
+ * Returns a consul request function, closure scopes the host configuration
  * of the service discovery system.
  *
  * @param host DNS or IP location of service discovery API
  */
-function serviceClient(host) {
+function consulClient(host) {
   /**
    * Discovers services and makes HTTP requests to them using "got" http client.
    *
@@ -24,7 +24,7 @@ function serviceClient(host) {
    *
    * @returns Promise
    */
-  function serviceRequest(config) {
+  function consulRequest(config) {
     var defaults = { endpoint: '', json: true };
     var settings = assign({}, defaults, config);
     var requestOptions = prepareRequestOptions(settings);
@@ -68,7 +68,7 @@ function serviceClient(host) {
     }
   }
 
-  return reqo(serviceRequest, ['serviceName', 'version']);
+  return reqo(consulRequest, ['serviceName', 'version']);
 }
 
-module.exports = serviceClient;
+module.exports = consulClient;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assign = require('lodash/object/assign');
-var got = require('got-promise');
+var got = require('got');
 var isEmpty = require('lodash/lang/isEmpty');
 var reqo = require('reqo');
 var sample = require('lodash/collection/sample');

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^2.9.30",
-    "got-promise": "^4.1.0",
+    "got": "^4.2.0",
     "lodash": "^3.9.1",
     "reqo": "0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consul-client",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/gulp test"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^2.10.2",
     "got": "^4.2.0",
     "lodash": "^3.9.1",
     "reqo": "0.0.1"

--- a/test/bluebird-test.js
+++ b/test/bluebird-test.js
@@ -5,7 +5,7 @@ var nock = require('nock');
 var withData = require('leche').withData;
 var consulClientBluebird = require('../bluebird');
 
-describe('service-client', function() {
+describe('consul-client/bluebird', function() {
   var host = 'my.service.discovery.host.com';
   var hostUrl = 'http://' + host;
   var serviceName = 'testService';
@@ -72,7 +72,7 @@ describe('service-client', function() {
     'PUT verb': putSetup,
     'DELETE verb': deleteSetup
   }, function(verb, bodyValidateFn, requestConfig) {
-    it('should make service request', function(done) {
+    it('should make consul request', function(done) {
       var address = 'test.service.com';
       var port = 4242;
       var serviceUrl = 'http://' + address + ':' + port;

--- a/test/bluebird-test.js
+++ b/test/bluebird-test.js
@@ -1,0 +1,137 @@
+var assert = require('assert');
+var format = require('util').format;
+var isEqual = require('lodash/lang/isEqual');
+var nock = require('nock');
+var withData = require('leche').withData;
+var consulClientBluebird = require('../bluebird');
+
+describe('service-client', function() {
+  var host = 'my.service.discovery.host.com';
+  var hostUrl = 'http://' + host;
+  var serviceName = 'testService';
+  var endpoint = 'testEndpoint';
+  var version = '1.0.0';
+  var sampleBody = { beep: 'boop' };
+  var getSetup;
+  var postSetup;
+  var putSetup;
+  var deleteSetup;
+  var consulRequest;
+
+  beforeEach(function() {
+    consulRequest = consulClientBluebird(host);
+  });
+
+  // =====================================
+  // Testing requests with HTTP verbs
+  // =====================================
+  getSetup = [
+    'get',
+    undefined,
+    { serviceName: serviceName, version: version, endpoint: endpoint }
+  ];
+
+  postSetup = [
+    'post',
+    function(body) { return isEqual(body, sampleBody); },
+    {
+      serviceName: serviceName,
+      version: version,
+      endpoint: endpoint,
+      method: 'POST',
+      body: sampleBody
+    }
+  ];
+
+  putSetup = [
+    'put',
+    function(body) { return isEqual(body, sampleBody); },
+    {
+      serviceName: serviceName,
+      version: version,
+      endpoint: endpoint,
+      method: 'PUT',
+      body: sampleBody
+    }
+  ];
+
+  deleteSetup = [
+    'delete',
+    undefined,
+    {
+      serviceName: serviceName,
+      version: version,
+      endpoint: endpoint,
+      method: 'DELETE'
+    }
+  ];
+
+  withData({
+    'GET verb': getSetup,
+    'POST verb': postSetup,
+    'PUT verb': putSetup,
+    'DELETE verb': deleteSetup
+  }, function(verb, bodyValidateFn, requestConfig) {
+    it('should make service request', function(done) {
+      var address = 'test.service.com';
+      var port = 4242;
+      var serviceUrl = 'http://' + address + ':' + port;
+      var serviceResponse = { foo: 'bar' };
+      var healthUrl = format(
+        '/v1/health/service/%s?passing&tag=%s',
+        requestConfig.serviceName,
+        version
+      );
+
+      // Health check call responds with one healthy service.
+      nock(hostUrl)
+        .get(healthUrl)
+        .reply(200, [{Service: {Address: address, Port: port}}]);
+
+      // Service call
+      nock(serviceUrl)
+        [verb]('/' + requestConfig.endpoint, bodyValidateFn)
+        .reply(200, serviceResponse);
+
+      consulRequest(requestConfig)
+        .then(function(response) {
+          assert.deepEqual(response.body, serviceResponse);
+          // Something to send through bluebird.map()
+          return ['foo', 'bar'];
+        })
+        .map(function(result) {
+          // bazify each item in the result set
+          return result + 'baz';
+        })
+        .then(function(arr) {
+          assert.deepEqual(arr, ['foobaz', 'barbaz']);
+          done();
+        });
+    });
+  });
+
+  // =====================================
+  // Testing service instances not found.
+  // =====================================
+  it('should throw an error if no healthy services are found', function(done) {
+    var healthUrl = format(
+      '/v1/health/service/%s?passing&tag=%s',
+      serviceName,
+      version
+    );
+
+    // Return empty array from service health check call
+    nock(hostUrl)
+      .get(healthUrl)
+      .reply(200, []);
+
+    // Results in an error, "no service instances available"
+    consulRequest({
+      serviceName: serviceName,
+      version: version
+    }).catch(function(err) {
+      assert.equal(err.message, 'no service instances available');
+      done();
+    });
+  });
+});

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -3,7 +3,7 @@ var format = require('util').format;
 var isEqual = require('lodash/lang/isEqual');
 var nock = require('nock');
 var withData = require('leche').withData;
-var serviceClient = require('../index');
+var consulClient = require('../index');
 
 describe('service-client', function() {
   var host = 'my.service.discovery.host.com';
@@ -16,10 +16,10 @@ describe('service-client', function() {
   var postSetup;
   var putSetup;
   var deleteSetup;
-  var serviceRequest;
+  var consulRequest;
 
   beforeEach(function() {
-    serviceRequest = serviceClient(host);
+    consulRequest = consulClient(host);
   });
 
   // =====================================
@@ -93,7 +93,7 @@ describe('service-client', function() {
         [verb]('/' + requestConfig.endpoint, bodyValidateFn)
         .reply(200, serviceResponse);
 
-      serviceRequest(requestConfig)
+      consulRequest(requestConfig)
         .then(function(response) {
           assert.deepEqual(response.body, serviceResponse);
           done();
@@ -117,7 +117,7 @@ describe('service-client', function() {
       .reply(200, []);
 
     // Results in an error, "no service instances available"
-    serviceRequest({
+    consulRequest({
       serviceName: serviceName,
       version: version
     }).catch(function(err) {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -5,7 +5,7 @@ var nock = require('nock');
 var withData = require('leche').withData;
 var consulClient = require('../index');
 
-describe('service-client', function() {
+describe('consul-client', function() {
   var host = 'my.service.discovery.host.com';
   var hostUrl = 'http://' + host;
   var serviceName = 'testService';
@@ -72,7 +72,7 @@ describe('service-client', function() {
     'PUT verb': putSetup,
     'DELETE verb': deleteSetup
   }, function(verb, bodyValidateFn, requestConfig) {
-    it('should make service request', function(done) {
+    it('should make consul request', function(done) {
       var address = 'test.service.com';
       var port = 4242;
       var serviceUrl = 'http://' + address + ':' + port;


### PR DESCRIPTION
### Upgrade Path

The `3.0.0` version of `consul-client` depended on a module called `got-promise` which returned promises backed by the expanded `bluebird` API for promises. The `got-promise` module is deprecated because `got` supports promises by default now. Version `4.0.0` of `consul-client` depends directly on `got`, but because `got` uses `pinkie-promise` as a Promise polyfill instead of `bluebird`, any code which used version `3.0.0` of `consul-client` and took advantage of `bluebird` features will break.. To fix this issue you can either not use any of the cool features of `bluebird` or you can explicitly wrap all of your calls to `consul-client` manually with `Bluebird.resolve`.

:exclamation: Important :exclamation: For convenience this wrapper is provided now, just change all of your `require('consul-client')` to `require('consul-client/bluebird')`.